### PR TITLE
Improve buffers

### DIFF
--- a/generator/counter_test.go
+++ b/generator/counter_test.go
@@ -105,7 +105,7 @@ func TestCounterNext(t *testing.T) {
 		}
 	}
 	assert.Equal(t, uint(66), c.time)
-	assert.True(t, 2 < c.value && c.value <= 7)
+	assert.True(t, 2 <= c.value && c.value <= 7)
 
 	// negative increment and zero deviation
 	c.time = 12


### PR DESCRIPTION
With previous implementation, UDP did fail with too big generators. E.g., `--random 'server{01..3}.soft{1..5}.metrics.random{001..100}' --from -20d --until -1s --step 30 --carbon 'udp://localhost:2003'` caused error:

```
Error: error while sending metrics, 0 bytes sent: write udp [::1]:40989->[::1]:2003: write: message too long
```

So, here's some kind of MTU precalculation that has been added.